### PR TITLE
Feat/filter results by status

### DIFF
--- a/apps/web/src/components/filter-details.tsx
+++ b/apps/web/src/components/filter-details.tsx
@@ -1,14 +1,19 @@
 "use client";
 import { Filter } from "lucide-react";
+import { useState } from "react";
 
 import { databases, dbIds, moneyRon } from "@/utils";
-import type { IndexName } from "@sicap/api";
+import type { IndexName, SearchStatusOption } from "@sicap/api";
 import type { SearchParams } from "./search-list";
 import { Dialog, DialogTrigger } from "@sicap/ui";
 import { AdvancedSearch } from "./search-advanced";
-import { useState } from "react";
 
-export function FilterDetails({ searchParams }: { searchParams: SearchParams }) {
+interface FilterDetailsProps {
+  searchParams: SearchParams;
+  statusOptions: SearchStatusOption[];
+}
+
+export function FilterDetails({ searchParams, statusOptions }: FilterDetailsProps) {
   const [open, setOpen] = useState(false);
 
   const {
@@ -26,10 +31,23 @@ export function FilterDetails({ searchParams }: { searchParams: SearchParams }) 
     localitySupplier,
     countySupplier,
     euFunds,
+    status,
   } = searchParams;
 
   const dbs = ((Array.isArray(db) ? db : db?.split(",")) || dbIds) as IndexName[];
   const dbLabelsAsText = dbs.map((db) => databases.find((d) => d.id === db)?.label).join(", ");
+  const statusTokens = new Set(
+    ((Array.isArray(status) ? status : status?.split(",")) ?? []).filter(Boolean),
+  );
+  const selectedStatuses = statusOptions.filter((option) => statusTokens.has(option.token));
+  const statusLabelsAsText = selectedStatuses
+    .map((option) => {
+      const databaseLabel = databases.find((database) => database.id === option.index)?.label;
+      return databaseLabel ? `${databaseLabel}: ${option.label}` : option.label;
+    })
+    .join(", ");
+  const showStatusSummary =
+    selectedStatuses.length > 0 && selectedStatuses.length < statusOptions.length;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -52,7 +70,8 @@ export function FilterDetails({ searchParams }: { searchParams: SearchParams }) 
           countySupplier ||
           supplier ||
           localitySupplier ||
-          euFunds ? (
+          euFunds ||
+          showStatusSummary ? (
             <>
               {dateFrom && <span className="mr-1">{`de la ${dateFrom}`}</span>}
               {dateTo && <span className="mr-1">{`până la ${dateTo};`}</span>}
@@ -74,11 +93,12 @@ export function FilterDetails({ searchParams }: { searchParams: SearchParams }) 
                 <span className="mr-1">{`; judet firma: ${countySupplier}.`}</span>
               )}
               {euFunds === "true" && <span className="mr-1">Fonduri Europene: DA.</span>}
+              {showStatusSummary && <span className="mr-1">{`Status: ${statusLabelsAsText}.`}</span>}
             </>
           ) : null}
         </button>
       </DialogTrigger>
-      <AdvancedSearch query={q} setOpen={setOpen} />
+      <AdvancedSearch query={q} setOpen={setOpen} statusOptions={statusOptions} />
     </Dialog>
   );
 }

--- a/apps/web/src/components/search-advanced.tsx
+++ b/apps/web/src/components/search-advanced.tsx
@@ -24,12 +24,14 @@ import {
   ScrollArea,
   ScrollBar,
 } from "@sicap/ui";
+import type { SearchStatusOption } from "@sicap/api";
 import { databases, dbIds } from "@/utils";
 import { captureAdvanceSearchButtonClick, captureClearFiltersButtonClick } from "@/lib/telemetry";
 import { useFormbricks } from "@/app/formbricks";
 
 const defaultValues = {
   db: dbIds,
+  status: [] as string[],
   q: "",
   dateFrom: "",
   dateTo: "",
@@ -50,6 +52,7 @@ const formSchema = z
     db: z.array(z.string()).refine((value) => value.some((item) => item), {
       message: "Selecteaza cel putin una.",
     }),
+    status: z.array(z.string()),
     q: z.string().optional(),
     dateFrom: z.string().optional(),
     dateTo: z.string().optional(),
@@ -118,21 +121,34 @@ const formSchema = z
 interface AdvancedSearchProps {
   query: string;
   setOpen: (open: boolean) => void;
+  statusOptions: SearchStatusOption[];
 }
 
-export function AdvancedSearch({ query, setOpen }: AdvancedSearchProps) {
+export function AdvancedSearch({ query, setOpen, statusOptions }: AdvancedSearchProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const db = searchParams.get("db");
   const { formbricks } = useFormbricks();
+  const defaultStatusTokens = useMemo(
+    () => statusOptions.map((option) => option.token),
+    [statusOptions],
+  );
+  const statusOptionsByDb = useMemo(() => {
+    return statusOptions.reduce<Record<string, SearchStatusOption[]>>((groups, option) => {
+      groups[option.index] ??= [];
+      groups[option.index].push(option);
+      return groups;
+    }, {});
+  }, [statusOptions]);
 
   const params = useMemo(
     () => ({
       ...Object.fromEntries(searchParams.entries()),
       db: db ? db.split(",") : dbIds,
+      status: searchParams.get("status")?.split(",") ?? defaultStatusTokens,
       euFunds: searchParams.get("euFunds") === "true",
     }),
-    [searchParams, db],
+    [searchParams, db, defaultStatusTokens],
   );
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -149,16 +165,29 @@ export function AdvancedSearch({ query, setOpen }: AdvancedSearchProps) {
   }, [form, params, query]);
 
   function handleReset() {
-    form.reset({ ...defaultValues, q: query });
+    form.reset({ ...defaultValues, q: query, status: defaultStatusTokens });
     captureClearFiltersButtonClick();
   }
 
   function onSubmit(values: z.infer<typeof formSchema>) {
+    if (statusOptions.length > 0 && values.status.length === 0) {
+      form.setError("status", {
+        type: "manual",
+        message: "Selecteaza cel putin un status.",
+      });
+      return;
+    }
+
+    const status =
+      values.status.length === defaultStatusTokens.length
+        ? undefined
+        : values.status.join(",");
     const params = new URLSearchParams(
       Array.from(
         Object.entries({
           ...values,
           db: values.db.join(","),
+          status,
         })
           .filter(([_, value]) => {
             return value !== "" && value !== undefined && value !== null;
@@ -255,6 +284,68 @@ export function AdvancedSearch({ query, setOpen }: AdvancedSearchProps) {
                   />
                 </div>
               </div>
+              {statusOptions.length > 0 && (
+                <div className="grid gap-4 py-4">
+                  <div className="grid grid-cols-4 items-start gap-4">
+                    <FormLabel htmlFor="status" className="text-right">
+                      Status
+                    </FormLabel>
+                    <FormField
+                      control={form.control}
+                      name="status"
+                      render={() => (
+                        <FormItem className="col-span-3">
+                          <div className="flex flex-col gap-4">
+                            {Object.entries(statusOptionsByDb).map(([databaseId, options]) => (
+                              <div key={databaseId} className="flex flex-col gap-2">
+                                <span className="text-xs font-medium text-muted-foreground">
+                                  {databases.find((database) => database.id === databaseId)?.label}
+                                </span>
+                                <div className="flex flex-col gap-2">
+                                  {options.map((option) => (
+                                    <FormField
+                                      key={option.token}
+                                      control={form.control}
+                                      name="status"
+                                      render={({ field }) => {
+                                        return (
+                                          <FormItem
+                                            key={option.token}
+                                            className="flex items-center space-x-2 space-y-0"
+                                          >
+                                            <FormControl>
+                                              <Checkbox
+                                                checked={field.value?.includes(option.token)}
+                                                onCheckedChange={(checked) => {
+                                                  return checked
+                                                    ? field.onChange([...field.value, option.token])
+                                                    : field.onChange(
+                                                        field.value?.filter(
+                                                          (value) => value !== option.token,
+                                                        ),
+                                                      );
+                                                }}
+                                              />
+                                            </FormControl>
+                                            <FormLabel className="text-right text-xs sm:text-sm">
+                                              {option.label}
+                                            </FormLabel>
+                                          </FormItem>
+                                        );
+                                      }}
+                                    />
+                                  ))}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                          <FormMessage withToast />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                </div>
+              )}
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label htmlFor="dateFrom" className="text-right">
                   Data publicarii

--- a/apps/web/src/components/search-list.tsx
+++ b/apps/web/src/components/search-list.tsx
@@ -1,6 +1,6 @@
 import { dbIds, formatNumber } from "@/utils";
-import type { IndexName } from "@sicap/api";
-import { searchContracts } from "@sicap/api";
+import type { IndexName, SearchStatusOption, SearchStatusSelection } from "@sicap/api";
+import { getSearchStatusOptions, searchContracts } from "@sicap/api";
 
 import { ListItem } from "./list-item";
 import { Pagination } from "./pagination";
@@ -26,10 +26,30 @@ export interface SearchParams {
   countySupplier: string;
   isFiscal?: string;
   euFunds?: string;
+  status?: string | string[];
 }
 
 interface SearchListProps {
   searchParams: SearchParams;
+}
+
+function parseStatusSelections(
+  status: string | string[] | undefined,
+  options: SearchStatusOption[],
+): SearchStatusSelection[] | undefined {
+  const tokens = Array.isArray(status) ? status : status?.split(",");
+
+  if (!tokens?.length) {
+    return undefined;
+  }
+
+  const optionByToken = new Map(options.map((option) => [option.token, option]));
+  const selections = tokens
+    .map((token) => optionByToken.get(token))
+    .filter((option): option is SearchStatusOption => Boolean(option))
+    .map(({ index, stateId }) => ({ index, stateId }));
+
+  return selections.length > 0 ? selections : undefined;
 }
 
 export async function SearchList({ searchParams }: SearchListProps) {
@@ -50,6 +70,7 @@ export async function SearchList({ searchParams }: SearchListProps) {
     localitySupplier,
     countySupplier,
     euFunds,
+    status,
   } = searchParams;
 
   const dbs = ((Array.isArray(db) ? db : db?.split(",")) || dbIds) as IndexName[];
@@ -70,11 +91,19 @@ export async function SearchList({ searchParams }: SearchListProps) {
     euFunds: euFunds === "true",
   };
 
+  const statusOptions = await getSearchStatusOptions({
+    query,
+    filters,
+  });
+
   const results = await searchContracts({
     query,
     page,
     perPage,
-    filters,
+    filters: {
+      ...filters,
+      status: parseStatusSelections(status, statusOptions),
+    },
   });
 
   return (
@@ -83,7 +112,7 @@ export async function SearchList({ searchParams }: SearchListProps) {
         Pagina {page} din {formatNumber(results.total)} rezultate pentru <b>{query}</b>
       </h3>
       <div className="flex items-center gap-4 justify-between">
-        <FilterDetails searchParams={searchParams} />
+        <FilterDetails searchParams={searchParams} statusOptions={statusOptions} />
         <div className="flex gap-2">
           <CSVDownload items={results.items} />
           <PerPage total={perPage} />

--- a/packages/api/src/es/search-contracts.ts
+++ b/packages/api/src/es/search-contracts.ts
@@ -12,7 +12,7 @@ import {
   transformItem,
   fieldsAchizitiiOffline,
 } from "./utils";
-import type { IndexName, SearchProps } from "./types";
+import type { IndexName, SearchFilters, SearchProps, SearchStatusOption } from "./types";
 
 const KEYWORD_SEARCH_FIELDS = {
   [ES_INDEX_PUBLIC]: [
@@ -90,6 +90,21 @@ const SUPPLIER_CUI_FIELDS = {
   offline: ["details.noticeEntityAddress.fiscalNumber"],
 } as const;
 
+const STATUS_FIELDS = {
+  [ES_INDEX_PUBLIC]: {
+    id: "item.sysProcedureState.id",
+    text: "item.sysProcedureState.text",
+  },
+  [ES_INDEX_DIRECT]: {
+    id: "item.sysDirectAcquisitionState.id",
+    text: "item.sysDirectAcquisitionState.text",
+  },
+  [ES_INDEX_OFFLINE]: {
+    id: "item.sysNoticeState.id",
+    text: "item.sysNoticeState.text",
+  },
+} as const;
+
 type CuiTerms = { numeric: string; roPrefixed: string };
 
 // Detects if query is a CUI and returns both numeric and RO-prefixed versions
@@ -165,14 +180,24 @@ const getAllCuiFields = () => [
   ...CUI_SEARCH_FIELDS[ES_INDEX_OFFLINE],
 ];
 
-export async function searchContracts({
-  query,
-  page = 1,
-  perPage = RESULTS_PER_PAGE,
-  filters,
-}: SearchProps) {
+function createStatusFilter(index: IndexName, filters: SearchFilters) {
+  const stateIds = filters.status
+    ?.filter((selection) => selection.index === index)
+    .map((selection) => selection.stateId);
+
+  if (!stateIds?.length) {
+    return undefined;
+  }
+
+  return {
+    terms: {
+      [STATUS_FIELDS[index].id]: stateIds,
+    },
+  };
+}
+
+function buildPublicFilters(filters: SearchFilters) {
   const {
-    db,
     dateFrom,
     dateTo,
     valueFrom,
@@ -187,362 +212,550 @@ export async function searchContracts({
     euFunds,
   } = filters;
 
+  return [
+    {
+      range: {
+        "item.noticeStateDate": {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+      },
+    },
+    valueFrom || valueTo
+      ? {
+          range: {
+            "noticeContracts.items.contractValue": {
+              gte: valueFrom ?? 0,
+              lte: valueTo ?? Number.MAX_SAFE_INTEGER,
+            },
+          },
+        }
+      : undefined,
+    createCuiAwareFilter(
+      authority,
+      "item.contractingAuthorityNameAndFN",
+      AUTHORITY_CUI_FIELDS.public,
+    ),
+    localityAuthority
+      ? {
+          bool: {
+            should: [
+              {
+                match_phrase: {
+                  "publicNotice.caNoticeEdit_New.section1_New.section1_1.caAddress.city":
+                    localityAuthority,
+                },
+              },
+              {
+                match_phrase: {
+                  "publicNotice.caNoticeEdit_New_U.section1_New_U.section1_1.caAddress.city":
+                    localityAuthority,
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+    countyAuthority
+      ? {
+          bool: {
+            should: [
+              {
+                match_phrase: {
+                  "publicNotice.caNoticeEdit_New.section1_New.section1_1.caAddress.county.text":
+                    countyAuthority,
+                },
+              },
+              {
+                match_phrase: {
+                  "publicNotice.caNoticeEdit_New.section1_New.section1_1.caAddress.nutsCodeItem.text":
+                    countyAuthority,
+                },
+              },
+              {
+                match_phrase: {
+                  "publicNotice.caNoticeEdit_New_U.section1_New_U.section1_1.caAddress.nutsCodeItem.text":
+                    countyAuthority,
+                },
+              },
+              {
+                match_phrase: {
+                  "publicNotice.caNoticeEdit_New_U.section1_New_U.section1_1.caAddress.county.text":
+                    countyAuthority,
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+    createCuiAwareFilter(
+      supplier,
+      "noticeContracts.items.winner.name",
+      SUPPLIER_CUI_FIELDS.public,
+    ),
+    localitySupplier
+      ? {
+          match_phrase: {
+            "noticeContracts.items.winner.address.city": localitySupplier,
+          },
+        }
+      : undefined,
+    countySupplier
+      ? {
+          bool: {
+            should: [
+              {
+                match_phrase: {
+                  "noticeContracts.items.winner.address.county.text": countySupplier,
+                },
+              },
+              {
+                match_phrase: {
+                  "noticeContracts.items.winner.address.nutsCodeItem.text": countySupplier,
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+    cpv
+      ? {
+          match_phrase: {
+            "item.cpvCodeAndName": cpv,
+          },
+        }
+      : undefined,
+    euFunds
+      ? {
+          bool: {
+            should: [
+              {
+                exists: {
+                  field:
+                    "publicNotice.caNoticeEdit_New.section2_New.section2_2_New.descriptionList.sysEuropeanFund.id",
+                },
+              },
+              {
+                exists: {
+                  field:
+                    "publicNotice.caNoticeEdit_New_U.section2_New_U.section2_2_New_U.descriptionList.sysEuropeanFund.id",
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+    createStatusFilter(ES_INDEX_PUBLIC, filters),
+  ].filter(Boolean);
+}
+
+function buildDirectFilters(filters: SearchFilters) {
+  const {
+    dateFrom,
+    dateTo,
+    valueFrom,
+    valueTo,
+    authority,
+    cpv,
+    localityAuthority,
+    countyAuthority,
+    supplier,
+    localitySupplier,
+    countySupplier,
+    euFunds,
+  } = filters;
+
+  return [
+    {
+      range: {
+        "item.publicationDate": {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+      },
+    },
+    {
+      range: {
+        "item.closingValue": {
+          gte: valueFrom,
+          lte: valueTo,
+        },
+      },
+    },
+    createCuiAwareFilter(authority, "item.contractingAuthority", AUTHORITY_CUI_FIELDS.direct),
+    localityAuthority
+      ? {
+          match_phrase: {
+            "authority.city": localityAuthority,
+          },
+        }
+      : undefined,
+    countyAuthority
+      ? {
+          match_phrase: {
+            "authority.county": countyAuthority,
+          },
+        }
+      : undefined,
+    createCuiAwareFilter(supplier, "item.supplier", SUPPLIER_CUI_FIELDS.direct),
+    localitySupplier
+      ? {
+          match_phrase: {
+            "supplier.city": localitySupplier,
+          },
+        }
+      : undefined,
+    countySupplier
+      ? {
+          match_phrase: {
+            "supplier.county": countySupplier,
+          },
+        }
+      : undefined,
+    cpv
+      ? {
+          match_phrase: {
+            "item.cpvCode": cpv,
+          },
+        }
+      : undefined,
+    euFunds
+      ? {
+          bool: {
+            should: [
+              {
+                exists: {
+                  field: "publicDirectAcquisition.sysEuropeanFund.id",
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+    createStatusFilter(ES_INDEX_DIRECT, filters),
+  ].filter(Boolean);
+}
+
+function buildOfflineFilters(filters: SearchFilters) {
+  const {
+    dateFrom,
+    dateTo,
+    valueFrom,
+    valueTo,
+    authority,
+    cpv,
+    localityAuthority,
+    countyAuthority,
+    supplier,
+    localitySupplier,
+    countySupplier,
+    euFunds,
+  } = filters;
+
+  return [
+    {
+      range: {
+        "item.publicationDate": {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+      },
+    },
+    {
+      range: {
+        "item.awardedValue": {
+          gte: valueFrom,
+          lte: valueTo,
+        },
+      },
+    },
+    createCuiAwareFilter(authority, "item.contractingAuthority", AUTHORITY_CUI_FIELDS.offline),
+    localityAuthority
+      ? {
+          match_phrase: {
+            "authority.city": localityAuthority,
+          },
+        }
+      : undefined,
+    countyAuthority
+      ? {
+          match_phrase: {
+            "authority.county": countyAuthority,
+          },
+        }
+      : undefined,
+    createCuiAwareFilter(supplier, "item.supplier", SUPPLIER_CUI_FIELDS.offline),
+    localitySupplier
+      ? {
+          match_phrase: {
+            "details.noticeEntityAddress.city": localitySupplier,
+          },
+        }
+      : undefined,
+    countySupplier
+      ? {
+          match_phrase: {
+            "supplier.county": countySupplier,
+          },
+        }
+      : undefined,
+    cpv
+      ? {
+          match_phrase: {
+            "item.cpvCode": cpv,
+          },
+        }
+      : undefined,
+    euFunds
+      ? {
+          bool: {
+            should: [
+              {
+                exists: {
+                  field: "details.sysEuropeanFund.id",
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+    createStatusFilter(ES_INDEX_OFFLINE, filters),
+  ].filter(Boolean);
+}
+
+function buildSearchShouldClauses(filters: SearchFilters) {
+  return [
+    {
+      bool: {
+        filter: buildPublicFilters(filters),
+      },
+    },
+    {
+      bool: {
+        filter: buildDirectFilters(filters),
+      },
+    },
+    {
+      bool: {
+        filter: buildOfflineFilters(filters),
+      },
+    },
+  ];
+}
+
+function buildKeywordMustClauses(query: string | undefined) {
+  const searchFields = getAllSearchFields();
+  const cuiFields = getAllCuiFields();
+  const cuiInfo = query ? getCuiSearchTerms(query) : { isCui: false as const };
+  const cuiSearchClauses = cuiInfo.isCui ? buildCuiClauses(cuiInfo, cuiFields) : [];
+
+  return [
+    query
+      ? {
+          bool: {
+            should: [
+              {
+                multi_match: {
+                  query,
+                  fields: searchFields,
+                  type: "best_fields",
+                  operator: "and",
+                  lenient: true,
+                },
+              },
+              {
+                multi_match: {
+                  query,
+                  fields: searchFields,
+                  type: "phrase",
+                  boost: 3,
+                  lenient: true,
+                },
+              },
+              ...cuiSearchClauses,
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : undefined,
+  ].filter(Boolean);
+}
+
+function buildSearchQuery(query: string | undefined, filters: SearchFilters) {
+  return {
+    bool: {
+      must: buildKeywordMustClauses(query),
+      filter: [
+        {
+          bool: {
+            should: buildSearchShouldClauses(filters),
+            minimum_should_match: 1,
+          },
+        },
+      ],
+    },
+  };
+}
+
+export async function getSearchStatusOptions({
+  query,
+  filters,
+}: {
+  query?: string;
+  filters: SearchFilters;
+}) {
+  const baseFilters = {
+    ...filters,
+    status: undefined,
+  };
+
+  const searchParams = {
+    index: filters.db,
+    body: {
+      size: 0,
+      query: buildSearchQuery(query, baseFilters),
+      aggs: {
+        public_statuses: {
+          filter: {
+            bool: {
+              filter: [
+                { term: { _index: ES_INDEX_PUBLIC } },
+                ...buildPublicFilters(baseFilters),
+              ],
+            },
+          },
+          aggs: {
+            statuses: {
+              terms: {
+                field: STATUS_FIELDS[ES_INDEX_PUBLIC].id,
+                size: 25,
+              },
+              aggs: {
+                label: {
+                  top_hits: {
+                    size: 1,
+                    _source: false,
+                    fields: [STATUS_FIELDS[ES_INDEX_PUBLIC].text],
+                  },
+                },
+              },
+            },
+          },
+        },
+        direct_statuses: {
+          filter: {
+            bool: {
+              filter: [
+                { term: { _index: ES_INDEX_DIRECT } },
+                ...buildDirectFilters(baseFilters),
+              ],
+            },
+          },
+          aggs: {
+            statuses: {
+              terms: {
+                field: STATUS_FIELDS[ES_INDEX_DIRECT].id,
+                size: 25,
+              },
+              aggs: {
+                label: {
+                  top_hits: {
+                    size: 1,
+                    _source: false,
+                    fields: [STATUS_FIELDS[ES_INDEX_DIRECT].text],
+                  },
+                },
+              },
+            },
+          },
+        },
+        offline_statuses: {
+          filter: {
+            bool: {
+              filter: [
+                { term: { _index: ES_INDEX_OFFLINE } },
+                ...buildOfflineFilters(baseFilters),
+              ],
+            },
+          },
+          aggs: {
+            statuses: {
+              terms: {
+                field: STATUS_FIELDS[ES_INDEX_OFFLINE].id,
+                size: 25,
+              },
+              aggs: {
+                label: {
+                  top_hits: {
+                    size: 1,
+                    _source: false,
+                    fields: [STATUS_FIELDS[ES_INDEX_OFFLINE].text],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await esClient.search(searchParams);
+  const aggregations = (result.aggregations ?? {}) as Record<string, any>;
+
+  return [ES_INDEX_PUBLIC, ES_INDEX_DIRECT, ES_INDEX_OFFLINE]
+    .flatMap((index) => {
+      const aggregation = aggregations[`${index}_statuses`];
+      const buckets = aggregation?.statuses?.buckets ?? [];
+      const textField = STATUS_FIELDS[index].text;
+
+      return buckets
+        .map((bucket: any) => {
+          const label = bucket.label?.hits?.hits?.[0]?.fields?.[textField]?.[0];
+
+          if (typeof label !== "string") {
+            return undefined;
+          }
+
+          return {
+            index,
+            stateId: Number(bucket.key),
+            label,
+            token: `${index}:${bucket.key}`,
+          } satisfies SearchStatusOption;
+        })
+        .filter(Boolean);
+    })
+    .sort((left, right) => {
+      if (left.index === right.index) {
+        return left.label.localeCompare(right.label, "ro");
+      }
+
+      return left.index.localeCompare(right.index, "en");
+    });
+}
+
+export async function searchContracts({
+  query,
+  page = 1,
+  perPage = RESULTS_PER_PAGE,
+  filters,
+}: SearchProps) {
+  const { db } = filters;
+
   if (
     db?.filter((d) => [ES_INDEX_DIRECT, ES_INDEX_PUBLIC, ES_INDEX_OFFLINE].includes(d)).length === 0
   ) {
     throw new Error("Baza de date nu este specificata.");
   }
 
-  const searchFields = getAllSearchFields();
-  const cuiFields = getAllCuiFields();
-  const cuiInfo = query ? getCuiSearchTerms(query) : { isCui: false as const };
-
-  const cuiSearchClauses = cuiInfo.isCui ? buildCuiClauses(cuiInfo, cuiFields) : [];
-
-  const querySearch = {
-    bool: {
-      must: [
-        query
-          ? {
-              bool: {
-                should: [
-                  {
-                    multi_match: {
-                      query: query,
-                      fields: searchFields,
-                      type: "best_fields",
-                      operator: "and",
-                      lenient: true,
-                    },
-                  },
-                  {
-                    multi_match: {
-                      query: query,
-                      fields: searchFields,
-                      type: "phrase",
-                      boost: 3,
-                      lenient: true,
-                    },
-                  },
-                  // Add CUI search clauses when query looks like a CUI
-                  ...cuiSearchClauses,
-                ],
-                minimum_should_match: 1,
-              },
-            }
-          : undefined,
-      ].filter(Boolean),
-      filter: [
-        {
-          bool: {
-            should: [
-              // licitatii publice
-              {
-                bool: {
-                  filter: [
-                    {
-                      range: {
-                        "item.noticeStateDate": {
-                          gte: dateFrom,
-                          lte: dateTo,
-                        },
-                      },
-                    },
-                    valueFrom || valueTo
-                      ? {
-                          range: {
-                            "noticeContracts.items.contractValue": {
-                              gte: valueFrom ?? 0,
-                              lte: valueTo ?? Number.MAX_SAFE_INTEGER,
-                            },
-                          },
-                        }
-                      : undefined,
-                    createCuiAwareFilter(
-                      authority,
-                      "item.contractingAuthorityNameAndFN",
-                      AUTHORITY_CUI_FIELDS.public,
-                    ),
-                    localityAuthority
-                      ? {
-                          bool: {
-                            should: [
-                              {
-                                match_phrase: {
-                                  "publicNotice.caNoticeEdit_New.section1_New.section1_1.caAddress.city":
-                                    localityAuthority,
-                                },
-                              },
-                              {
-                                match_phrase: {
-                                  "publicNotice.caNoticeEdit_New_U.section1_New_U.section1_1.caAddress.city":
-                                    localityAuthority,
-                                },
-                              },
-                            ],
-                            minimum_should_match: 1,
-                          },
-                        }
-                      : undefined,
-                    countyAuthority
-                      ? {
-                          bool: {
-                            should: [
-                              {
-                                match_phrase: {
-                                  "publicNotice.caNoticeEdit_New.section1_New.section1_1.caAddress.county.text":
-                                    countyAuthority,
-                                },
-                              },
-                              {
-                                match_phrase: {
-                                  "publicNotice.caNoticeEdit_New.section1_New.section1_1.caAddress.nutsCodeItem.text":
-                                    countyAuthority,
-                                },
-                              },
-                              {
-                                match_phrase: {
-                                  "publicNotice.caNoticeEdit_New_U.section1_New_U.section1_1.caAddress.nutsCodeItem.text":
-                                    countyAuthority,
-                                },
-                              },
-                              {
-                                match_phrase: {
-                                  "publicNotice.caNoticeEdit_New_U.section1_New_U.section1_1.caAddress.county.text":
-                                    countyAuthority,
-                                },
-                              },
-                            ],
-                            minimum_should_match: 1,
-                          },
-                        }
-                      : undefined,
-                    createCuiAwareFilter(
-                      supplier,
-                      "noticeContracts.items.winner.name",
-                      SUPPLIER_CUI_FIELDS.public,
-                    ),
-                    localitySupplier
-                      ? {
-                          match_phrase: {
-                            "noticeContracts.items.winner.address.city": localitySupplier,
-                          },
-                        }
-                      : undefined,
-                    countySupplier
-                      ? {
-                          bool: {
-                            should: [
-                              {
-                                match_phrase: {
-                                  "noticeContracts.items.winner.address.county.text":
-                                    countySupplier,
-                                },
-                              },
-                              {
-                                match_phrase: {
-                                  "noticeContracts.items.winner.address.nutsCodeItem.text":
-                                    countySupplier,
-                                },
-                              },
-                            ],
-                            minimum_should_match: 1,
-                          },
-                        }
-                      : undefined,
-                    cpv
-                      ? {
-                          match_phrase: {
-                            "item.cpvCodeAndName": cpv,
-                          },
-                        }
-                      : undefined,
-                    euFunds
-                      ? {
-                          bool: {
-                            should: [
-                              {
-                                exists: {
-                                  field:
-                                    "publicNotice.caNoticeEdit_New.section2_New.section2_2_New.descriptionList.sysEuropeanFund.id",
-                                },
-                              },
-                              {
-                                exists: {
-                                  field:
-                                    "publicNotice.caNoticeEdit_New_U.section2_New_U.section2_2_New_U.descriptionList.sysEuropeanFund.id",
-                                },
-                              },
-                            ],
-                            minimum_should_match: 1,
-                          },
-                        }
-                      : undefined,
-                  ].filter(Boolean),
-                },
-              },
-              // achizitii directe
-              {
-                bool: {
-                  filter: [
-                    {
-                      range: {
-                        "item.publicationDate": {
-                          gte: dateFrom,
-                          lte: dateTo,
-                        },
-                      },
-                    },
-                    {
-                      range: {
-                        "item.closingValue": {
-                          gte: valueFrom,
-                          lte: valueTo,
-                        },
-                      },
-                    },
-                    createCuiAwareFilter(
-                      authority,
-                      "item.contractingAuthority",
-                      AUTHORITY_CUI_FIELDS.direct,
-                    ),
-                    localityAuthority
-                      ? {
-                          match_phrase: {
-                            "authority.city": localityAuthority,
-                          },
-                        }
-                      : undefined,
-                    countyAuthority
-                      ? {
-                          match_phrase: {
-                            "authority.county": countyAuthority,
-                          },
-                        }
-                      : undefined,
-                    createCuiAwareFilter(supplier, "item.supplier", SUPPLIER_CUI_FIELDS.direct),
-                    localitySupplier
-                      ? {
-                          match_phrase: {
-                            "supplier.city": localitySupplier,
-                          },
-                        }
-                      : undefined,
-                    countySupplier
-                      ? {
-                          match_phrase: {
-                            "supplier.county": countySupplier,
-                          },
-                        }
-                      : undefined,
-                    cpv
-                      ? {
-                          match_phrase: {
-                            "item.cpvCode": cpv,
-                          },
-                        }
-                      : undefined,
-                    euFunds
-                      ? {
-                          bool: {
-                            should: [
-                              {
-                                exists: {
-                                  field: "publicDirectAcquisition.sysEuropeanFund.id",
-                                },
-                              },
-                            ],
-                            minimum_should_match: 1,
-                          },
-                        }
-                      : undefined,
-                  ].filter(Boolean),
-                },
-              },
-              // achizitii offline
-              {
-                bool: {
-                  filter: [
-                    {
-                      range: {
-                        "item.publicationDate": {
-                          gte: dateFrom,
-                          lte: dateTo,
-                        },
-                      },
-                    },
-                    {
-                      range: {
-                        "item.awardedValue": {
-                          gte: valueFrom,
-                          lte: valueTo,
-                        },
-                      },
-                    },
-                    createCuiAwareFilter(
-                      authority,
-                      "item.contractingAuthority",
-                      AUTHORITY_CUI_FIELDS.offline,
-                    ),
-                    localityAuthority
-                      ? {
-                          match_phrase: {
-                            "authority.city": localityAuthority,
-                          },
-                        }
-                      : undefined,
-                    countyAuthority
-                      ? {
-                          match_phrase: {
-                            "authority.county": countyAuthority,
-                          },
-                        }
-                      : undefined,
-                    createCuiAwareFilter(supplier, "item.supplier", SUPPLIER_CUI_FIELDS.offline),
-                    localitySupplier
-                      ? {
-                          match_phrase: {
-                            "details.noticeEntityAddress.city": localitySupplier,
-                          },
-                        }
-                      : undefined,
-                    countySupplier
-                      ? {
-                          match_phrase: {
-                            "supplier.county": countySupplier,
-                          },
-                        }
-                      : undefined,
-                    cpv
-                      ? {
-                          match_phrase: {
-                            "item.cpvCode": cpv,
-                          },
-                        }
-                      : undefined,
-                    euFunds
-                      ? {
-                          bool: {
-                            should: [
-                              {
-                                exists: {
-                                  field: "details.sysEuropeanFund.id",
-                                },
-                              },
-                            ],
-                            minimum_should_match: 1,
-                          },
-                        }
-                      : undefined,
-                  ].filter(Boolean),
-                },
-              },
-            ],
-          },
-        },
-      ],
-    },
-  };
+  const querySearch = buildSearchQuery(query, filters);
 
   const searchParams = {
     index: db,
@@ -588,7 +801,7 @@ export async function searchContracts({
   return {
     took: result.took,
     total: total.value,
-    items: result?.hits?.hits?.map((hit) => ({
+    items: result?.hits?.hits?.map((hit: (typeof result.hits.hits)[number]) => ({
       id: hit._id as string,
       index: hit._index as IndexName,
       fields: transformItem(hit._index, hit.fields as Fields, hit.highlight as Fields),

--- a/packages/api/src/es/types.ts
+++ b/packages/api/src/es/types.ts
@@ -2,6 +2,16 @@ import type { ES_INDEX_DIRECT, ES_INDEX_OFFLINE, ES_INDEX_PUBLIC } from "./utils
 
 export type IndexName = typeof ES_INDEX_PUBLIC | typeof ES_INDEX_DIRECT | typeof ES_INDEX_OFFLINE;
 
+export interface SearchStatusSelection {
+  index: IndexName;
+  stateId: number;
+}
+
+export interface SearchStatusOption extends SearchStatusSelection {
+  label: string;
+  token: string;
+}
+
 export interface SearchFilters {
   db?: IndexName[];
   dateFrom?: string;
@@ -16,6 +26,7 @@ export interface SearchFilters {
   localitySupplier?: string;
   countySupplier?: string;
   euFunds?: boolean;
+  status?: SearchStatusSelection[];
 }
 export interface SearchProps {
   query: string;


### PR DESCRIPTION
Adds status filtering for `/cauta` endpoint with a multiselect that defaults to all available statuses, so existing behavior stays unchanged unless the user narrows it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status filtering capability to search results. Users can now select specific statuses to filter contracts. Status selections appear in the filter summary when applied and can be combined with other search criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->